### PR TITLE
Removed witness inv from all messages but get_data

### DIFF
--- a/src/protocols/protocol_block_in.cpp
+++ b/src/protocols/protocol_block_in.cpp
@@ -232,12 +232,7 @@ bool protocol_block_in::handle_receive_headers(const code& ec,
         /*LOG_INFO(LOG_NODE)
             << " protocol_block_in::handle_receive_headers (block) ["
             << authority() << "] ";*/
-#ifdef BITPRIM_CURRENCY_BCH
     message->to_inventory(response->inventories(), inventory::type_id::block);
-#else
-    // Witness: only request/accept witness block to fully validate the txns
-    message->to_inventory(response->inventories(), inventory::type_id::witness_block);
-#endif
     }
    
     // Remove hashes of blocks that we already have.
@@ -267,12 +262,7 @@ bool protocol_block_in::handle_receive_inventory(const code& ec,
           /*LOG_INFO(LOG_NODE)
             << " protocol_block_in::handle_receive_inventory (block) ["
             << authority() << "] ";*/
-#ifdef BITPRIM_CURRENCY_BCH
     message->reduce(response->inventories(), inventory::type_id::block);
-#else
-    // Witness: only request/accept witness block to fully validate the txns
-    message->reduce(response->inventories(), inventory::type_id::witness_block);
-#endif
     }
     
     // Remove hashes of blocks that we already have.
@@ -299,14 +289,14 @@ void protocol_block_in::send_get_data(const code& ec, get_data_ptr message)
 
 
     if (compact_from_peer_) {
-        
+
         if (node_.node_settings().compact_blocks_high_bandwidth) {
 #ifdef BITPRIM_CURRENCY_BCH
             uint64_t compact_version = 1;
 #else
             uint64_t compact_version = 2;
 #endif
-            
+
             if ( ! compact_blocks_high_bandwidth_set_ && ! chain_.is_stale() ) {
                 LOG_INFO(LOG_NODE) << "The chain is not stale, send sendcmcpt with high bandwidth ["<< authority() << "]";
                 SEND2((send_compact{true, compact_version}), handle_send, _1, send_compact::command);
@@ -325,8 +315,6 @@ void protocol_block_in::send_get_data(const code& ec, get_data_ptr message)
     // Enqueue the block inventory behind the preceding block inventory.
     for (const auto& inventory: message->inventories()){
         if (inventory.type() == inventory::type_id::block) {
-            backlog_.push(inventory.hash());
-        } else if (inventory.type() == inventory::type_id::witness_block) {
             backlog_.push(inventory.hash());
         } else if (inventory.type() == inventory::type_id::compact_block) {
             backlog_.push(inventory.hash());
@@ -368,12 +356,7 @@ bool protocol_block_in::handle_receive_not_found(const code& ec,
     }
 
     hash_list hashes;
-#ifdef BITPRIM_CURRENCY_BCH
     message->to_hashes(hashes, inventory::type_id::block);
-#else
-    // Witness: only request/accept witness block to fully validate the txns
-    message->to_hashes(hashes, inventory::type_id::witness_block);
-#endif
 
     for (const auto& hash: hashes)
     {
@@ -736,12 +719,7 @@ void protocol_block_in::send_get_data_compact_block(const code& ec, const hash_d
     hashes.push_back(hash);
 
     get_data_ptr request;
-#ifdef BITPRIM_CURRENCY_BCH
     request = std::make_shared<get_data>(hashes, inventory::type_id::block);
-#else
-    // Witness: only request/accept witness block to fully validate the txns
-    request = std::make_shared<get_data>(hashes, inventory::type_id::witness_block);
-#endif
 
     send_get_data(ec,request);
 }

--- a/src/protocols/protocol_transaction_in.cpp
+++ b/src/protocols/protocol_transaction_in.cpp
@@ -125,12 +125,7 @@ bool protocol_transaction_in::handle_receive_inventory(const code& ec,
     const auto response = std::make_shared<get_data>();
 
     // Copy the transaction inventories into a get_data instance.
-#ifdef BITPRIM_CURRENCY_BCH
     message->reduce(response->inventories(), inventory::type_id::transaction);
-#else    
-    // Witness: only request/accept witness txns for complete validation
-    message->reduce(response->inventories(), inventory::type_id::witness_transaction);
-#endif    
 
     // TODO: move relay to a derived class protocol_transaction_in_70001.
     // Prior to this level transaction relay is not configurable.
@@ -263,12 +258,7 @@ void protocol_transaction_in::handle_store_transaction(const code& ec,
 void protocol_transaction_in::send_get_transactions(
     transaction_const_ptr message)
 {
-#ifdef BITPRIM_CURRENCY_BCH
     inventory::type_id type = inventory::type_id::transaction;
-#else    
-    // Witness: only request/accept witness txns for complete validation
-    inventory::type_id type = inventory::type_id::witness_transaction;
-#endif    
 
     auto missing = message->missing_previous_transactions();
 


### PR DESCRIPTION
> New inv types MSG_WITNESS_TX (0x40000001, or (1<<30)+MSG_TX) and MSG_WITNESS_BLOCK (0x40000002, or (1<<30)+MSG_BLOCK) are added, only for use in getdata. Inventory messages themselves still use just MSG_TX and MSG_BLOCK, similar to MSG_FILTERED_BLOCK. A further inv type MSG_FILTERED_WITNESS_BLOCK (0x40000003, or (1<<30)+MSG_FILTERED_BLOCK) is reserved for future use.

https://github.com/bitcoin/bips/blob/master/bip-0144.mediawiki